### PR TITLE
Fix condition for windows app icon path

### DIFF
--- a/public/app/AppTray.js
+++ b/public/app/AppTray.js
@@ -16,7 +16,7 @@ module.exports = class AppTray extends Tray {
       iconPath = Util.getAssetPath(
         "/icons/mac/png/icon.png"
       );
-    } else if (process.platform !== "win32") {
+    } else if (process.platform === "win32") {
       iconPath = Util.getAssetPath("/icons/win/icon.ico");
     }
     log.info(`[AppTray] iconPath=${iconPath}`);


### PR DESCRIPTION
When running the app in dev, I was receiving an error message about the app icon:
```
[FATAL] [App] Error: Failed to load image from path '~/flow-insight-fork/public/assets/icons/win/icon.ico'
```
When I looked at the conditions, it appears its checking if the OS isn't Windows and then setting it to the windows icon.

I didn't test the Windows build to see if that win/icon.ico path breaks that build though.